### PR TITLE
Reset the page title direction after toggle

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,6 @@ const main = async () => {
     .content {
     }
     .ls-page-title.title {
-      direction: rtl;
     }
       `,
         });


### PR DESCRIPTION
First off, thanks for this plugin :+1: 
I noticed an issue when toggling RTL on and off, the page title stays on the right.
This little change seems to fix the issue.